### PR TITLE
feat: 홈 페이지 개편 - 오늘 일정 subtitle 연동 및 HotEventRow Badge 적용 (#40)

### DIFF
--- a/src/components/main/adaptive/feature/HOM/CalendarSection.jsx
+++ b/src/components/main/adaptive/feature/HOM/CalendarSection.jsx
@@ -1,4 +1,4 @@
-import { useState, useMemo } from "react";
+import { useState, useMemo, useEffect } from "react";
 import { useNavigate } from "react-router-dom";
 import { useQuery, keepPreviousData } from "@tanstack/react-query";
 import {
@@ -18,7 +18,7 @@ import { FILTER_OPTIONS } from "@/constants/filterOption";
 import { useCalendarPrefetch } from "@/hooks/useCalendarPrefetch";
 import SectionTitle from "@/components/main/mobile/common/SectionTitle";
 
-const CalendarSection = () => {
+const CalendarSection = ({ onTodayEventCount }) => {
   const [selectedFilter, setSelectedFilter] = useState(["CONTEST"]);
   const isMobile = useDeviceStore((state) => state.isMobile);
   const navigate = useNavigate();
@@ -106,6 +106,14 @@ const CalendarSection = () => {
     });
     return eventMap;
   }, [data]); // data가 변경될 때만 재계산
+
+  // 오늘 일정 개수를 부모(HOMPage)로 전달
+  useEffect(() => {
+    if (!onTodayEventCount) return;
+    const todayKey = formatDateKey(new Date());
+    const count = eventsByDate[todayKey]?.length ?? 0;
+    onTodayEventCount(count);
+  }, [eventsByDate, onTodayEventCount]);
 
   /******핸들러 핸들러 핸들러*******/
   const scrollToEventList = () => {

--- a/src/components/main/mobile/feature/HOM/HotEventRow.jsx
+++ b/src/components/main/mobile/feature/HOM/HotEventRow.jsx
@@ -1,44 +1,21 @@
-import { FILTER_OPTIONS } from "@/constants/filterOption";
+import Badge from "@/components/main/adaptive/common/Badge";
 
 const HotEventRow = ({
   article_id = "",
   category = "기타",
   title = "오류",
-  vendor = "미확인",
-  start_date = "",
-  due_date = "",
-  bookmarks = 0,
   onArticleClick,
 }) => {
   if (!article_id || !title) return null;
 
-  const option = FILTER_OPTIONS.find((o) => o.key === category);
-  const label = option?.label ?? "기타";
-  const tagBg = option?.tagBg ?? "bg-gray-200";
-  const HandleEventClick = (article_id, category_name) => {
-    onArticleClick(article_id, category_name);
-  };
   return (
     <div className="m-1 w-60 shrink-0">
       <div
-        className="bg-white p-4 rounded-xl  flex flex-col gap-1 shadow-sm max-mobile:h-24 h-26 "
-        onClick={() => HandleEventClick(article_id, category)}
+        className="bg-white p-4 rounded-xl flex flex-col gap-1 shadow-sm max-mobile:h-24 h-26"
+        onClick={() => onArticleClick(article_id, category)}
       >
-        <div
-          className={`self-start px-2 py-0.5 rounded text-sm max-mobile:text-xs font-medium text-black ${tagBg} mb-1`}
-        >
-          {label}
-        </div>
-        <div className="font-medium text-gray-700  line-clamp-2 text-sm">{
-        title
-       }</div>
-        {/**
-         *   <div className="text-xs">{vendor}</div>
-        <div className="text-xs">
-          <p>{`${start_date} ~ ${due_date}`}</p>
-        </div>
-        <div className="text-xs">{`북마크 ${bookmarks}`}</div>
-         */}
+        <Badge category={category} className="self-start text-xs px-2 py-0.5 font-medium mb-1" />
+        <div className="font-medium text-gray-700 line-clamp-2 text-sm">{title}</div>
       </div>
     </div>
   );

--- a/src/pages/main/HOM/HOMPage.jsx
+++ b/src/pages/main/HOM/HOMPage.jsx
@@ -7,12 +7,27 @@ import { useDeviceStore } from "@/stores/deviceStore";
 import MobileHeader from "@/components/main/mobile/common/MobileHeader";
 import MobileTabBar from "@/components/main/mobile/common/MobileTabBar";
 import MobileFooter from "@/components/main/mobile/common/MobileFooter";
-import { useEffect } from "react";
+import { useState, useCallback, useEffect } from "react";
 import { useQueryClient } from "@tanstack/react-query";
 import { fetchClubs } from "@/api/main/articles";
 const HOMPage = () => {
   const isMobile = useDeviceStore((state) => state.isMobile);
   const queryClient = useQueryClient();
+  const [todayEventCount, setTodayEventCount] = useState(null);
+
+  const handleTodayEventCount = useCallback((count) => {
+    setTodayEventCount(count);
+  }, []);
+
+  // subtitle 계산: 로딩 중(null)이면 undefined, 0개면 없어요, n개면 n개
+  const subtitle = isMobile
+    ? todayEventCount === null
+      ? undefined
+      : todayEventCount === 0
+        ? "오늘의 일정이 없어요."
+        : `오늘은 ${todayEventCount}개의 일정이 있어요.`
+    : undefined;
+
   useEffect(() => {
     queryClient.prefetchQuery({
       queryKey: ["clubs", "", 1], // 1단계에서 정한 key와 동일
@@ -35,7 +50,7 @@ const HOMPage = () => {
       }
     >
       {isMobile ? (
-        <MobileHeader greeting />
+        <MobileHeader greeting subtitle={subtitle} />
       ) : (
         <div className="max-mobile:hidden">
           <TabBar />
@@ -56,7 +71,7 @@ const HOMPage = () => {
             {/* <ClubCarousel /> 동아리 랜덤 포스터 API 제거로 임시 미사용 */}
           </aside>
           <main className="flex-1 min-w-0 w-full space-y-6">
-            <CalendarSection />
+            <CalendarSection onTodayEventCount={handleTodayEventCount} />
           </main>
         </div>
       </div>


### PR DESCRIPTION
## Summary
- `CalendarSection`에 `onTodayEventCount` 선택적 콜백 prop 추가 — `eventsByDate` 변경 시 오늘 일정 개수를 부모(`HOMPage`)로 전달
- `HOMPage`에 `todayEventCount` state + `handleTodayEventCount` 콜백 추가 — 데이터 로딩 전(null)·0개·n개에 따라 `MobileHeader subtitle` 동적 생성
- `HotEventRow`에서 `FILTER_OPTIONS` 직접 조회 제거 → `Badge category` prop으로 교체, 미사용 props(`vendor`, `start_date`, `due_date`, `bookmarks`) 제거

## Test plan
- [ ] `npm run dev` → 모바일(430px) 뷰, 홈 페이지
- [ ] MobileHeader에 "오늘은 N개의 일정이 있어요." 표시 확인
- [ ] 오늘 일정이 없는 날: "오늘의 일정이 없어요." 표시 확인
- [ ] 데이터 로딩 중 subtitle 표시 안 됨 확인
- [ ] HOT 공지사항 카드 카테고리 배지가 Badge 컴포넌트로 표시 확인
- [ ] 필터 변경 시 subtitle 카운트 영향 없음 확인 (오늘 일정 기준, 필터 독립)

closes #40

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **새로운 기능**
  * 모바일 메인 화면에서 오늘 일정 개수를 확인할 수 있습니다.
  * 오늘 일정이 없을 때는 “오늘의 일정이 없어요.” 안내가 표시됩니다.
  * 일정 정보를 불러오는 동안에는 불필요한 안내 문구가 표시되지 않습니다.
  * 인기 이벤트의 카테고리가 색상과 라벨이 적용된 배지로 더 명확하게 표시됩니다.
  * 인기 이벤트를 선택하면 해당 콘텐츠로 바로 이동합니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->